### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ You'll then want to copy the contents of `config/config.ts.example` into 2 new f
 | developers      | String[] | Discord User IDs of you and fellow developers. These can use commands that are devOnly. |
 | infoChannel     | String   | Discord Channel ID where info should be logged to.                                      |
 | errorChannel    | String   | Discord Channel ID where errors should be logged to.                                    |
-| accentColor     | String   | Basic color of all embeds, as well as the welcome cards.                                |
+| accentColor     | String   | Basic color of all embeds, as well as the welcome cards, must be in hex!                |
 | backgroundImage | String   | Default background image of the welcome card. Placed in `assets/images`.                |
 | imgurID         | String   | This is the Imgur API Token listed in the [requirements](#requirements).                |
 | dblToken        | String   | This is the DBL API Token listed in the [requirements](#requirements).                  |

--- a/config/config.ts.example
+++ b/config/config.ts.example
@@ -5,7 +5,7 @@ export default {
     developers: [''], // Discord User IDs of you and fellow developers. These can use commands that are devOnly
     infoChannel: '', // Discord Channel ID of a channel, where info should be logged to
     errorChannel: '', // Discord Channel ID where errors should be logged to
-    accentColor: '', // Basic color of all embeds, as well as the welcome cards.
+    accentColor: '', // Basic color of all embeds, as well as the welcome cards, only hexa is supported as format of colour!
     backgroundImage: 'autumn-forest.jpg', // Default background image of the welcome card. Placed in assets/images
     imgurID: '',
     dblToken: ''


### PR DESCRIPTION
precise that accent colour is an hexa as the bot don't work if you use other types of colour formats.